### PR TITLE
Ajout lien vers profil NeTEx accessibilité France

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,5 +14,5 @@ Les composants principaux d'AccesLibre Mobilités sont
 * une application mobile, pour compléter les attributs d'accessibilité lors de relevés sur le terrain
 
 Les données ainsi crées peuvent ensuite être exportées dans le format d'échange 
-NeTEx accessibilité, conformément au cadre réglementaire en France.
+[NeTEx au profil accessibilité France](https://normes.transport.data.gouv.fr/normes/netex/accessibilité/), conformément au cadre réglementaire en France.
 


### PR DESCRIPTION
Je propose cet ajout de lien, pour faire passer le message que le profil est disponible en ligne.

On gagnerait probablement aussi à mettre un lien vers:
- https://github.com/etalab/transport-profil-netex-fr/tree/main/NeTEx/accessibilité
- https://github.com/etalab/transport-profil-netex-fr/issues (en invitant à ouvrir un ticket en cas de questions)

Voilà, à discuter, c'est juste une idée pour faire une comm supplémentaire sur le cadre réglementaire !